### PR TITLE
Fix import name in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ yarn add next-goatcounter
 Now, in `_app.js`
 
 ```js
-import { GCScript } from "goatcounter-nextjs";
+import { GCScript } from "next-goatcounter";
 ```
 and in `return`
 
@@ -38,9 +38,9 @@ To send custom events to GoatCounter,
 
 first
 ```js
-import { GCEvent } from "goatcounter-nextjs";
+import { GCEvent } from "next-goatcounter";
 ```
 then use `GCEvent` like this
 ```js
-GCEvent(path,title);
+GCEvent(path, title);
 ```


### PR DESCRIPTION
Hi!

I had to make these changes to import the plugin.

Perhaps it was renamed during development :)