### PR TITLE
Make scriptSrc optional

### DIFF
--- a/src/components.tsx
+++ b/src/components.tsx
@@ -8,7 +8,7 @@ declare global {
   }
 }
 
-export const GCScript: React.FC<{siteUrl: string, scriptSrc: string}>= ({ siteUrl, scriptSrc }) => {
+export const GCScript: React.FC<{siteUrl: string, scriptSrc?: string}>= ({ siteUrl, scriptSrc }) => {
   const router = useRouter();
   useEffect(() => {
     const handleRouteChange = (url) => {


### PR DESCRIPTION
This makes the `scriptSrc` prop on the `GCScript` component optional as the `README` indicates it is not required and the `components.tsx` file has a fallback at line #29: `src={scriptSrc ?? "//gc.zgo.at/count.js"}`.