### PR TITLE
Remove `@babel/cli` from dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,10 +40,10 @@
     "@types/react": "^17.0.39",
     "@types/react-dom": "^17.0.11",
     "del-cli": "^4.0.1",
-    "typescript": "^4.5.5"
+    "typescript": "^4.5.5",
+    "@babel/cli": "^7.16.8"
   },
   "dependencies": {
-    "@babel/cli": "^7.16.8"
   },
   "funding": "https://buymeacoffee.com/HAliPunjabi",
   "repository": {


### PR DESCRIPTION
Do we really need it when using the project?